### PR TITLE
Fix PSR-7 immutability, add input validation, strict types, and other hardening.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 /.phpunit.cache
 .DS_Store
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": "^8.2", 
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.1"
+        "psr/http-factory": "^1.1",
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "license": "WTFPL",
     "require-dev": {

--- a/src/Exception/FailedToCreateConsentCookieException.php
+++ b/src/Exception/FailedToCreateConsentCookieException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/InvalidVideoIdException.php
+++ b/src/Exception/InvalidVideoIdException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/NoTranscriptAvailableException.php
+++ b/src/Exception/NoTranscriptAvailableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/NoTranscriptFoundException.php
+++ b/src/Exception/NoTranscriptFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/NotTranslatableException.php
+++ b/src/Exception/NotTranslatableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/PoTokenRequiredException.php
+++ b/src/Exception/PoTokenRequiredException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 class PoTokenRequiredException extends \Exception implements YoutubeTranscriptExceptionInterface

--- a/src/Exception/TooManyRequestsException.php
+++ b/src/Exception/TooManyRequestsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/TranscriptsDisabledException.php
+++ b/src/Exception/TranscriptsDisabledException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/TranslationLanguageNotAvailableException.php
+++ b/src/Exception/TranslationLanguageNotAvailableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/VideoUnavailableException.php
+++ b/src/Exception/VideoUnavailableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/YouTubeRequestFailedException.php
+++ b/src/Exception/YouTubeRequestFailedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Exception/YoutubeTranscriptExceptionInterface.php
+++ b/src/Exception/YoutubeTranscriptExceptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript\Exception;
 
 use Exception;

--- a/src/Transcript.php
+++ b/src/Transcript.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript;
 
 use Psr\Http\Client\ClientInterface;
@@ -7,7 +9,6 @@ use MrMySQL\YoutubeTranscript\Exception\NotTranslatableException;
 use MrMySQL\YoutubeTranscript\Exception\YouTubeRequestFailedException;
 use MrMySQL\YoutubeTranscript\Exception\TranslationLanguageNotAvailableException;
 use Psr\Http\Message\RequestFactoryInterface;
-use Throwable;
 
 class Transcript
 {
@@ -43,9 +44,9 @@ class Transcript
             throw new Exception\PoTokenRequiredException();
         }
         try {
-            $request = $this->request_factory->createRequest('GET', $this->url);
-            $request->withHeader('Accept-Language', 'en-US');
-            $request->withHeader('Content-Type', 'text/html; charset=utf-8');
+            $request = $this->request_factory->createRequest('GET', $this->url)
+                ->withHeader('Accept-Language', 'en-US')
+                ->withHeader('Content-Type', 'text/html; charset=utf-8');
             $response = $this->http_client->sendRequest($request);
             if ($response->getStatusCode() >= 400) {
                 throw new YouTubeRequestFailedException($response->getReasonPhrase());
@@ -55,8 +56,10 @@ class Transcript
                 $response->getBody()->getContents(),
                 $preserve_formatting
             );
-        } catch (Throwable $e) {
-            throw new YouTubeRequestFailedException($e->getMessage());
+        } catch (YouTubeRequestFailedException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            throw new YouTubeRequestFailedException($e->getMessage(), 0, $e);
         }
     }
 
@@ -84,7 +87,7 @@ class Transcript
             $this->http_client,
             $this->request_factory,
             $this->video_id,
-            $this->url . '&tlang=' . $language_code,
+            $this->url . '&tlang=' . urlencode($language_code),
             $this->translation_languages_dict[$language_code],
             $language_code,
             true,

--- a/src/TranscriptList.php
+++ b/src/TranscriptList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript;
 
 use Traversable;

--- a/src/TranscriptListFetcher.php
+++ b/src/TranscriptListFetcher.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript;
 
 use MrMySQL\YoutubeTranscript\Exception\FailedToCreateConsentCookieException;
+use MrMySQL\YoutubeTranscript\Exception\InvalidVideoIdException;
 use MrMySQL\YoutubeTranscript\Exception\NoTranscriptAvailableException;
 use MrMySQL\YoutubeTranscript\Exception\TooManyRequestsException;
 use MrMySQL\YoutubeTranscript\Exception\TranscriptsDisabledException;
@@ -34,6 +37,12 @@ class TranscriptListFetcher
 
     public function fetch(string $video_id): TranscriptList
     {
+        if (!preg_match('/^[a-zA-Z0-9_-]{11}$/', $video_id)) {
+            throw new InvalidVideoIdException(
+                sprintf('Invalid video ID: "%s". Expected an 11-character YouTube video ID.', $video_id)
+            );
+        }
+
         $video_page_html = $this->fetchVideoHtml($video_id);
         $api_key = $this->extractInnertubeApiKey($video_page_html, $video_id);
         $innertube_data = $this->fetchInnertubeData($video_id, $api_key);
@@ -46,9 +55,9 @@ class TranscriptListFetcher
                 $this->extractVideoTitle($video_page_html)
             );
         } catch (\Throwable $th) {
-            $this->logger?->debug('Loaded video page content. video id: {video_id}, content: {content}', [
+            $this->logger?->debug('Failed to build transcript list for video {video_id}: {error}', [
                 'video_id' => $video_id,
-                'content' => $video_page_html,
+                'error' => $th->getMessage(),
             ]);
             throw $th;
         }
@@ -124,11 +133,11 @@ class TranscriptListFetcher
     private function fetchHtml(string $video_id, string $with_consent = ''): string
     {
         $url = sprintf(self::WATCH_URL, $video_id);
-        $request = $this->request_factory->createRequest('GET', $url);
-        $request->withHeader('Accept-Language', 'en-US');
+        $request = $this->request_factory->createRequest('GET', $url)
+            ->withHeader('Accept-Language', 'en-US');
 
         if ($with_consent) {
-            $request->withHeader('Set-Cookie', 'CONSENT=YES+' . $with_consent . '; Domain=.youtube.com; Path=/; HttpOnly');
+            $request = $request->withHeader('Cookie', 'CONSENT=YES+' . $with_consent);
         }
 
         $response = $this->http_client->sendRequest($request);

--- a/src/TranscriptParser.php
+++ b/src/TranscriptParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MrMySQL\YoutubeTranscript;
 
 class TranscriptParser


### PR DESCRIPTION
PSR-7 immutability — The withHeader() return values are now chained/assigned instead of discarded. This is a fix that actually changes runtime behavior. Headers will now be sent, and the EU consent cookie flow will work.

Set-Cookie → Cookie — The consent header was using a server-side response header name. Changed to the correct client-side Cookie header and stripped the Domain/Path/HttpOnly directives that only a server sends.

Video ID validation — fetch() now rejects anything that isn't exactly 11 characters of [a-zA-Z0-9_-], using the InvalidVideoIdException that was already defined but unused.

Exception narrowing — Transcript::fetch() no longer catches Throwable. It re-throws YouTubeRequestFailedException directly and wraps other \Exception types with the original chained as a previous exception for debugging.

Translation URL encoding — urlencode() on the tlang query parameter.

Log sanitization — The debug logger no longer dumps the full YouTube HTML page. It logs the error message instead.
psr/log dependency — Added to composer.json require since the constructor accepts ?LoggerInterface.

composer.lock removed — Untracked and added to .gitignore, which is standard for libraries.

declare(strict_types=1) — Added to every PHP file.