### PR TITLE
Distinguish YouTube bot-block from disabled transcripts

### DIFF
--- a/src/Exception/RequestBlockedException.php
+++ b/src/Exception/RequestBlockedException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MrMySQL\YoutubeTranscript\Exception;
+
+use Exception;
+
+/**
+ * Thrown when YouTube blocks the request as suspected bot traffic
+ * (e.g. playabilityStatus.status = LOGIN_REQUIRED, "Sign in to confirm you’re not a bot").
+ *
+ * This is distinct from TranscriptsDisabledException: the video may well have
+ * transcripts, but the requesting IP/proxy was refused. Callers can use this to
+ * blacklist a blocked proxy rather than concluding the video has no captions.
+ */
+class RequestBlockedException extends Exception implements YoutubeTranscriptExceptionInterface
+{
+
+}

--- a/src/TranscriptListFetcher.php
+++ b/src/TranscriptListFetcher.php
@@ -5,6 +5,7 @@ namespace MrMySQL\YoutubeTranscript;
 use MrMySQL\YoutubeTranscript\Exception\FailedToCreateConsentCookieException;
 use MrMySQL\YoutubeTranscript\Exception\NoTranscriptAvailableException;
 use MrMySQL\YoutubeTranscript\Exception\TooManyRequestsException;
+use MrMySQL\YoutubeTranscript\Exception\RequestBlockedException;
 use MrMySQL\YoutubeTranscript\Exception\TranscriptsDisabledException;
 use MrMySQL\YoutubeTranscript\Exception\YouTubeRequestFailedException;
 use Psr\Http\Client\ClientInterface;
@@ -93,7 +94,19 @@ class TranscriptListFetcher
         if (!isset($innertube_data['playabilityStatus'])) {
             throw new YouTubeRequestFailedException('Missing playabilityStatus');
         }
-        // TODO: Add playability status checks and throw appropriate exceptions as in Python
+
+        $playability_status = $innertube_data['playabilityStatus'];
+        $status = $playability_status['status'] ?? null;
+        $reason = $playability_status['reason'] ?? '';
+
+        // YouTube refuses suspected bot traffic with LOGIN_REQUIRED and a reason like
+        // "Sign in to confirm you’re not a bot", stripping captions from the response.
+        // Surface this distinctly so callers don't mistake a blocked IP/proxy for a
+        // video that genuinely has transcripts disabled.
+        if ($status === 'LOGIN_REQUIRED' && stripos($reason, 'bot') !== false) {
+            throw new RequestBlockedException($video_id . ': ' . $reason);
+        }
+
         $captions_json = $innertube_data['captions']['playerCaptionsTracklistRenderer'] ?? null;
         if ($captions_json === null) {
             throw new TranscriptsDisabledException($video_id);

--- a/tests/TranscriptListFetcherTest.php
+++ b/tests/TranscriptListFetcherTest.php
@@ -8,6 +8,7 @@ use MrMySQL\YoutubeTranscript\TranscriptList;
 use MrMySQL\YoutubeTranscript\Exception\FailedToCreateConsentCookieException;
 use MrMySQL\YoutubeTranscript\Exception\TooManyRequestsException;
 use MrMySQL\YoutubeTranscript\Exception\TranscriptsDisabledException;
+use MrMySQL\YoutubeTranscript\Exception\RequestBlockedException;
 use MrMySQL\YoutubeTranscript\Exception\YouTubeRequestFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientInterface;
@@ -94,6 +95,27 @@ class TranscriptListFetcherTest extends TestCase
             'captions' => [
                 'playerCaptionsTracklistRenderer' => null
             ]
+        ];
+        $this->mockRequest($html, json_encode($innertubeJson));
+
+        $this->transcriptListFetcher->fetch($videoId);
+    }
+
+    public function testFetchRequestBlockedExceptionWhenLoginRequired(): void
+    {
+        // When YouTube bot-blocks the request (e.g. from a flagged datacenter/proxy IP),
+        // the innertube response has playabilityStatus.status = LOGIN_REQUIRED and no captions.
+        // This must be reported as a RequestBlockedException, NOT TranscriptsDisabledException,
+        // so callers can tell a blocked proxy apart from a genuinely caption-less video.
+        $this->expectException(RequestBlockedException::class);
+
+        $videoId = 'video123';
+        $html = '<html>{"INNERTUBE_API_KEY":"test_api_key"}</html>';
+        $innertubeJson = [
+            'playabilityStatus' => [
+                'status' => 'LOGIN_REQUIRED',
+                'reason' => 'Sign in to confirm you’re not a bot',
+            ],
         ];
         $this->mockRequest($html, json_encode($innertubeJson));
 


### PR DESCRIPTION
## Problem

When YouTube refuses suspected bot traffic (e.g. from a flagged datacenter/proxy IP), the innertube `player` response returns **HTTP 200** with `playabilityStatus.status = LOGIN_REQUIRED` (reason: *"Sign in to confirm you're not a bot"*) and the `captions` object **stripped out** — even for videos that genuinely have transcripts.

`extractCaptionsJson()` treated *any* captions-less response as `TranscriptsDisabledException`, so a blocked IP was indistinguishable from a video that truly has transcripts disabled. Callers (e.g. a proxy health-checker) couldn't tell "this proxy is blocked" from "this video has no captions".

This was reproduced live: a video with a valid auto-generated transcript returned `LOGIN_REQUIRED`/no-captions through a flagged proxy IP, surfacing as `TranscriptsDisabledException`.

## Change

- Add `RequestBlockedException` (implements `YoutubeTranscriptExceptionInterface`).
- `extractCaptionsJson()` now inspects `playabilityStatus`; on the `LOGIN_REQUIRED` bot-block it throws `RequestBlockedException` instead of `TranscriptsDisabledException`.
- A status-`OK` response with no captions still maps to `TranscriptsDisabledException` (genuinely disabled) — existing behavior preserved.

This replaces the long-standing `// TODO: Add playability status checks` in `extractCaptionsJson()`.

## Tests

- New `testFetchRequestBlockedExceptionWhenLoginRequired` (TDD: written failing first).
- Full suite green: **28 tests, 36 assertions**. Existing `testFetchTranscriptsDisabledException` still passes, confirming the genuine-no-captions path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)